### PR TITLE
Fix bug where using the same email address in upper and lower case would create separate user records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,13 +30,15 @@ group :development do
   gem 'guard-livereload', '~> 2.4', require: false
   gem 'rack-livereload'
   gem 'web-console', '~> 2.0'
-  gem 'byebug'
   gem 'mailcatcher'
 end
 
 group :test do
   gem 'assert_difference'
   gem 'capybara'
+end
+
+group :test, :development do
   gem 'byebug'
 end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,8 +8,10 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by_email(params[:email])
-    user = User.create!(email: params[:email]) if user.nil?
+    email = params.require(:email).strip.downcase
+
+    user = User.find_by_email(email)
+    user = User.create!(email: email) if user.nil?
     user.token = SecureRandom.hex
     user.save!
 

--- a/db/migrate/20160227135307_combine_duplicate_emails.rb
+++ b/db/migrate/20160227135307_combine_duplicate_emails.rb
@@ -1,0 +1,70 @@
+class CombineDuplicateEmails < ActiveRecord::Migration
+  def change
+    canonicalise_emails = 'UPDATE USERS SET email = TRIM(LOWER(email));'
+
+    create_mapping_table = <<-QUERY
+      CREATE TEMPORARY TABLE user_mappings AS
+      SELECT currents.id as current_id, canonicals.id as new_id
+      FROM USERS currents
+      INNER JOIN
+      (
+        SELECT a.email, a.id
+        FROM USERS a
+        WHERE a.id = (
+          SELECT MIN(b.id)
+          FROM USERS b
+          WHERE b.email = a.email
+        )
+      ) canonicals
+      ON currents.email = canonicals.email
+      WHERE currents.id != canonicals.id;
+    QUERY
+
+    update_topics = <<-QUERY
+      UPDATE topics
+      SET owner_id = user_mappings.new_id
+      FROM user_mappings
+      WHERE topics.owner_id = user_mappings.current_id;
+    QUERY
+
+    update_comments = <<-QUERY
+      UPDATE comments
+      SET author_id = user_mappings.new_id
+      FROM user_mappings
+      WHERE comments.author_id = user_mappings.current_id;
+    QUERY
+
+    update_topic_teachers = <<-QUERY
+      UPDATE topic_teachers
+      SET user_id = user_mappings.new_id
+      FROM user_mappings
+      WHERE topic_teachers.user_id = user_mappings.current_id;
+    QUERY
+
+    update_topic_students = <<-QUERY
+      UPDATE topic_students
+      SET user_id = user_mappings.new_id
+      FROM user_mappings
+      WHERE topic_students.user_id = user_mappings.current_id;
+    QUERY
+
+    delete_old_users = <<-QUERY
+      DELETE FROM USERS
+      WHERE id IN (
+        SELECT current_id
+        FROM user_mappings
+      );
+    QUERY
+
+    drop_mapping_table = 'DROP TABLE user_mappings;'
+
+    execute canonicalise_emails
+    execute create_mapping_table
+    execute update_topics
+    execute update_comments
+    execute update_topic_teachers
+    execute update_topic_students
+    execute delete_old_users
+    execute drop_mapping_table
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150617045154) do
+ActiveRecord::Schema.define(version: 20160227135307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe SessionsController, type: :controller do
 
       it 'should not create user' do
         assert_difference 'User.count', 0 do
-          post :create, email: 'dave@example.com'
+          post :create, email: 'DAVE@example.com '
         end
       end
 


### PR DESCRIPTION
Also fixed warning in Gemfile.

There will be orphan user accounts floating around after this goes live (if people have been using `Name@domain.com` instead of `name@domain.com` to log in), so we might want to add a migration to combine the duplicate accounts.
